### PR TITLE
Fix/update shopping item

### DIFF
--- a/components/Form/Form.js
+++ b/components/Form/Form.js
@@ -1,21 +1,20 @@
 import styled from "styled-components";
 
 /*
-1. 
 - This form is designed to handle both "creating" and "updating" a shopping item.
 - therefore it makes sense to rename this component to "Form"
 - Use a more generic prop name like "onSubmitItem" so the function can be used for both creating and updating an item.
 - The actuall function is therefore passed as a prop by the parent component.
-- You can also pass the submitLabel, depending on whether you want to create or update an item, the default could be "submit"
+- You can also pass the "submitLabel", depending on whether you want to create or update an item, the default could be "submit"
 - To make the form prefilled, you also need the information about which item is to be updated, so we need this information as prop "item"
 */
 export default function Form({
-  onSubmitItem,
-  submitLabel,
+  onSubmitItem, // Function to handle item submission (create or update).
+  submitLabel, // Label for the submit button (e.g., "Submit" or "Update").
   categories,
-  item = {},
-  onChangeMode,
-  mode,
+  item = {}, // Default is an empty object, holds the item data if available for editing.
+  onChangeMode, // Function to change the mode (e.g., from "edit" to "create").
+  mode, // Current mode of the form, either "create" or "edit".
 }) {
   function handleSubmit(event) {
     event.preventDefault();
@@ -24,12 +23,16 @@ export default function Form({
     newItem.quantity = Number(newItem.quantity);
     newItem.imageUrl = "placeholder_1.png";
 
+    /*
+    - If the item has an ID (means it's being updated -> item prop is not an emtpy array), call "onSubmitItem "with the item ID.
+    - Otherwise, call "onSubmitItem" for creating a new item.
+    */
     if (item.id) {
       onSubmitItem(item.id, newItem);
     } else {
       onSubmitItem(newItem);
     }
-
+    // Resets the form mode after submission. So the from is "hidden"
     onChangeMode("");
   }
 
@@ -37,8 +40,8 @@ export default function Form({
     <article>
       <form onSubmit={handleSubmit}>
         <StyledFieldset>
-          {/* 💡 add a condition for updtaing or creating an Item */}
-          {/* <h2>{item.id ? "Update" : "Add"} an item to the list:</h2> */}
+          {/* Condition to show either "Update" or "Add" based on item existence */}
+          <h2>{item.id ? "Update" : "Add"} an item to the list:</h2>
           <StyledLabel>
             new shopping item*:
             <StyledInput
@@ -46,7 +49,7 @@ export default function Form({
               type="text"
               required
               placeholder="e.g., salt"
-              // 💡 Pre-fill when "updating"
+              //  If updating an item, pre-fill the input with its current name.
               defaultValue={item.name || ""}
             />
           </StyledLabel>
@@ -56,7 +59,7 @@ export default function Form({
               name="quantity"
               type="number"
               required
-              // 💡 Pre-fill when "updating"
+              // 💡 Pre-fill with the existing quantity or default to 1.
               defaultValue={item.quantity || 1}
             />
           </StyledLabel>
@@ -65,6 +68,7 @@ export default function Form({
             <select
               name="category"
               required
+              // Pre-fill the selected category if in "edit" mode, otherwise leave it blank.
               defaultValue={mode === "edit" ? item.category : ""}
             >
               <option value="">please select a category</option>
@@ -133,15 +137,3 @@ const StyledFieldset = styled.fieldset`
   align-content: start;
   list-style-type: none;
 `;
-
-// const StyledForm = styled.form`
-//   display: flex;
-//   flex-direction: column;
-//   padding: 16px;
-//   border-radius: 5px;
-//   background-color: lightgrey;
-//   border: none;
-//   gap: 6px;
-//   align-content: start;
-//   list-style-type: none;
-// `;

--- a/components/Form/Form.js
+++ b/components/Form/Form.js
@@ -1,6 +1,22 @@
 import styled from "styled-components";
 
-export default function FormToCreateShoppingItem({ onAddItem, categories }) {
+/*
+1. 
+- This form is designed to handle both "creating" and "updating" a shopping item.
+- therefore it makes sense to rename this component to "Form"
+- Use a more generic prop name like "onSubmitItem" so the function can be used for both creating and updating an item.
+- The actuall function is therefore passed as a prop by the parent component.
+- You can also pass the submitLabel, depending on whether you want to create or update an item, the default could be "submit"
+- To make the form prefilled, you also need the information about which item is to be updated, so we need this information as prop "item"
+*/
+export default function Form({
+  onSubmitItem,
+  submitLabel,
+  categories,
+  item = {},
+  onChangeMode,
+  mode,
+}) {
   function handleSubmit(event) {
     event.preventDefault();
     const formData = new FormData(event.target);
@@ -8,20 +24,21 @@ export default function FormToCreateShoppingItem({ onAddItem, categories }) {
     newItem.quantity = Number(newItem.quantity);
     newItem.imageUrl = "placeholder_1.png";
 
-    onAddItem(newItem);
-    event.target.reset();
+    if (item.id) {
+      onSubmitItem(item.id, newItem);
+    } else {
+      onSubmitItem(newItem);
+    }
+
+    onChangeMode("");
   }
 
   return (
     <article>
-      <form
-        // add id for form here as reference
-        id={FormToCreateShoppingItem}
-        onSubmit={handleSubmit}
-        data-js="form"
-      >
+      <form onSubmit={handleSubmit}>
         <StyledFieldset>
-          <h2>Add an item to the list:</h2>
+          {/* 💡 add a condition for updtaing or creating an Item */}
+          {/* <h2>{item.id ? "Update" : "Add"} an item to the list:</h2> */}
           <StyledLabel>
             new shopping item*:
             <StyledInput
@@ -29,22 +46,33 @@ export default function FormToCreateShoppingItem({ onAddItem, categories }) {
               type="text"
               required
               placeholder="e.g., salt"
+              // 💡 Pre-fill when "updating"
+              defaultValue={item.name || ""}
             />
           </StyledLabel>
           <StyledLabel>
             number*:
-            <StyledInput name="quantity" type="number" required />
+            <StyledInput
+              name="quantity"
+              type="number"
+              required
+              // 💡 Pre-fill when "updating"
+              defaultValue={item.quantity || 1}
+            />
           </StyledLabel>
           <StyledLabel>
             category*:
-            <select key="category" name="category" data-js="category" required>
+            <select
+              name="category"
+              required
+              defaultValue={mode === "edit" ? item.category : ""}
+            >
               <option value="">please select a category</option>
               {categories.map((category) => (
                 <option key={category.name} value={category.name}>
                   {category.name}
                 </option>
               ))}
-              ;
             </select>
           </StyledLabel>
           <StyledLabel>
@@ -53,13 +81,16 @@ export default function FormToCreateShoppingItem({ onAddItem, categories }) {
               name="comment"
               type="text"
               placeholder="Enter comments here..."
+              // 💡 Pre-fill when "updating"
+              defaultValue={item.comment || ""}
             />
           </StyledLabel>
           <StyledNote>
             Required fields are followed by <span aria-label="required">*</span>
             .
           </StyledNote>
-          <StyledButton>Submit</StyledButton>
+          {/* Here you use what is in the submitLabel prop. So either "submit" or "update" */}
+          <StyledButton>{submitLabel}</StyledButton>
         </StyledFieldset>
       </form>
     </article>

--- a/components/FormToCreateShoppingItem/FormToCreateShoppingItem.js
+++ b/components/FormToCreateShoppingItem/FormToCreateShoppingItem.js
@@ -14,7 +14,12 @@ export default function FormToCreateShoppingItem({ onAddItem, categories }) {
 
   return (
     <article>
-      <form onSubmit={handleSubmit} data-js="form">
+      <form
+        // add id for form here as reference
+        id={FormToCreateShoppingItem}
+        onSubmit={handleSubmit}
+        data-js="form"
+      >
         <StyledFieldset>
           <h2>Add an item to the list:</h2>
           <StyledLabel>

--- a/components/ShoppingItem/ShoppingItem.js
+++ b/components/ShoppingItem/ShoppingItem.js
@@ -2,25 +2,16 @@ import styled from "styled-components";
 import Link from "next/link";
 import { useState } from "react";
 
-// pass onEditItem down
-// pass id down
 export default function ShoppingItem({
-  id,
   onDeleteItem,
   shoppingItem,
   onEditItem,
+  onChangeMode,
 }) {
   const [isToBeDeleted, setIsToBeDeleted] = useState(false);
 
-  // set UseState for isToBeEdited
-  const [isToBeEdited, setIsToBeEdited] = useState(false);
-
   function toggleIsToBeDeleted() {
     setIsToBeDeleted(!isToBeDeleted);
-  }
-
-  function toggleIsToBeEdited() {
-    setIsToBeEdited(!isToBeEdited);
   }
 
   return (
@@ -30,23 +21,19 @@ export default function ShoppingItem({
     >
       <CategoryBox>{shoppingItem.category}</CategoryBox>
 
-      {/* {isToBeEdited && } */}
-
       {!isToBeDeleted ? (
         <>
           {shoppingItem.quantity} {shoppingItem.name}
           {/* add isToBeEditedButton: */}
-          {/* NewItem not needed as argument here, only in the form itself */}
           <EditButton
             onClick={() => {
-              toggleIsToBeEdited(id);
-              ("location.href='FormToCreateShoppingItem'");
+              onChangeMode();
+              onEditItem();
             }}
-            data-js="isToBeEditedButton"
           >
             edit
           </EditButton>
-          {/* upon clicking on "edit", the form gets focused, prefilled and titled with sth. like "Edit the {id.name}"" */}
+          {/* NewItem not needed as argument here, only in the form itself */}
           <DeleteButton
             onClick={() => {
               toggleIsToBeDeleted(shoppingItem);
@@ -66,7 +53,6 @@ export default function ShoppingItem({
             onClick={() => {
               toggleIsToBeDeleted(shoppingItem);
             }}
-            data-js="cancelDeleteButton"
           >
             Cancel
           </button>
@@ -74,7 +60,6 @@ export default function ShoppingItem({
             onClick={() => {
               onDeleteItem(shoppingItem.id);
             }}
-            data-js="confirmDeleteButton"
           >
             Delete
           </button>

--- a/components/ShoppingItem/ShoppingItem.js
+++ b/components/ShoppingItem/ShoppingItem.js
@@ -2,11 +2,25 @@ import styled from "styled-components";
 import Link from "next/link";
 import { useState } from "react";
 
-export default function ShoppingItem({ onDeleteItem, shoppingItem }) {
+// pass onEditItem down
+// pass id down
+export default function ShoppingItem({
+  id,
+  onDeleteItem,
+  shoppingItem,
+  onEditItem,
+}) {
   const [isToBeDeleted, setIsToBeDeleted] = useState(false);
+
+  // set UseState for isToBeEdited
+  const [isToBeEdited, setIsToBeEdited] = useState(false);
 
   function toggleIsToBeDeleted() {
     setIsToBeDeleted(!isToBeDeleted);
+  }
+
+  function toggleIsToBeEdited() {
+    setIsToBeEdited(!isToBeEdited);
   }
 
   return (
@@ -16,17 +30,31 @@ export default function ShoppingItem({ onDeleteItem, shoppingItem }) {
     >
       <CategoryBox>{shoppingItem.category}</CategoryBox>
 
+      {/* {isToBeEdited && } */}
+
       {!isToBeDeleted ? (
         <>
           {shoppingItem.quantity} {shoppingItem.name}
-          <ToggleDeleteButton
+          {/* add isToBeEditedButton: */}
+          {/* NewItem not needed as argument here, only in the form itself */}
+          <EditButton
+            onClick={() => {
+              toggleIsToBeEdited(id);
+              ("location.href='FormToCreateShoppingItem'");
+            }}
+            data-js="isToBeEditedButton"
+          >
+            edit
+          </EditButton>
+          {/* upon clicking on "edit", the form gets focused, prefilled and titled with sth. like "Edit the {id.name}"" */}
+          <DeleteButton
             onClick={() => {
               toggleIsToBeDeleted(shoppingItem);
             }}
             data-js="toggleIsToBeDeletedButton"
           >
             delete
-          </ToggleDeleteButton>
+          </DeleteButton>
           <StyledLink href={`/shoppingItems/${shoppingItem.id}`}>
             Details
           </StyledLink>
@@ -56,11 +84,35 @@ export default function ShoppingItem({ onDeleteItem, shoppingItem }) {
   );
 }
 
-const ToggleDeleteButton = styled.button`
+// {/* add toggle isToDeEditedButton to cancel Editing */}
+// <button
+//   onClick={() => {
+//     toggleIsToBeEdited(shoppingItem);
+//   }}
+//   data-js="cancelEditButton"
+// >
+//   Cancel
+// </button>
+// {/*  */}
+
+const DeleteButton = styled.button`
   display: flex;
   position: absolute;
   bottom: 10%;
   right: 5rem;
+  /* padding: 2px 5px;
+  background-color: #eee;
+  color: #333;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: normal; */
+`;
+
+const EditButton = styled.button`
+  display: flex;
+  position: absolute;
+  bottom: 10%;
+  right: 10rem;
   /* padding: 2px 5px;
   background-color: #eee;
   color: #333;

--- a/components/ShoppingItem/ShoppingItem.js
+++ b/components/ShoppingItem/ShoppingItem.js
@@ -19,6 +19,7 @@ export default function ShoppingItem({ onDeleteItem, shoppingItem }) {
       {!isToBeDeleted ? (
         <>
           {shoppingItem.quantity} {shoppingItem.name}
+          {/* {shoppingItem.quantity > 1 ? shoppingItem.pluralForm : shoppingItem.entity + shoppingItem.name} */}
           <ToggleDeleteButton
             onClick={() => {
               toggleIsToBeDeleted(shoppingItem);

--- a/components/ShoppingItem/ShoppingItem.js
+++ b/components/ShoppingItem/ShoppingItem.js
@@ -19,7 +19,6 @@ export default function ShoppingItem({ onDeleteItem, shoppingItem }) {
       {!isToBeDeleted ? (
         <>
           {shoppingItem.quantity} {shoppingItem.name}
-          {/* {shoppingItem.quantity > 1 ? shoppingItem.pluralForm : shoppingItem.entity + shoppingItem.name} */}
           <ToggleDeleteButton
             onClick={() => {
               toggleIsToBeDeleted(shoppingItem);

--- a/lib/shoppingItemsData.js
+++ b/lib/shoppingItemsData.js
@@ -6,8 +6,8 @@ export const shoppingItems = [
     quantity: 2,
     category: "Dairy",
     comment: "low-fat, 1 litre each, prefer brand A",
-    entity: "carton of ",
-    pluralForm: "cartons of milk",
+    // entity: "carton of ",
+    // pluralForm: "cartons of milk",
   },
   {
     id: "2",

--- a/lib/shoppingItemsData.js
+++ b/lib/shoppingItemsData.js
@@ -6,8 +6,8 @@ export const shoppingItems = [
     quantity: 2,
     category: "Dairy",
     comment: "low-fat, 1 litre each, prefer brand A",
-    // entity: "carton of ";
-    // pluralForm: "cartons of";
+    entity: "carton of ",
+    pluralForm: "cartons of milk",
   },
   {
     id: "2",
@@ -16,7 +16,7 @@ export const shoppingItems = [
     quantity: 1,
     category: "Bakery",
     // entity: "loaf of ";
-    // pluralForm: "loaves of";
+    // pluralForm: "loaves of bread";
     comment: "whole grain, large loaf, no seeds",
   },
   {
@@ -66,7 +66,7 @@ export const shoppingItems = [
     quantity: 1,
     category: "Snacks",
     // entity: "package of ";
-    // pluralForm: "packages of";
+    // pluralForm: "packages of" ;
     comment: "salted, large bag, prefer brand C",
   },
   {
@@ -75,6 +75,8 @@ export const shoppingItems = [
     imageUrl: "dish-soap.png",
     quantity: 1,
     category: "Household",
+    // entity: "bottle of ";
+    // pluralForm: "bottles of";
     comment: "lemon scented, 500ml, eco-friendly",
   },
   {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -10,6 +10,8 @@ export default function App({ Component, pageProps }) {
   const [showForm, setShowForm] = useState(false);
 
   function handleAddItem(newItem) {
+    console.log("blah");
+
     setShoppingItems([
       {
         id: nanoid(),

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,6 +7,16 @@ import { nanoid } from "nanoid";
 export default function App({ Component, pageProps }) {
   const [shoppingItems, setShoppingItems] = useState(initialShoppingItems);
 
+  // function handleEditItem(id, propertyToBeChanged) {
+  //   setShoppingItems([
+
+  //     shoppingItems.map((shoppingItem) => {
+  //       if (shoppingItem.id === id) return {newItem, shoppingItems};
+  //       return shoppingItem;
+  //     })
+  //   ]);
+  // }
+
   function handleAddItem(newItem) {
     setShoppingItems([
       {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,16 +6,8 @@ import { nanoid } from "nanoid";
 
 export default function App({ Component, pageProps }) {
   const [shoppingItems, setShoppingItems] = useState(initialShoppingItems);
-
-  // function handleEditItem(id, propertyToBeChanged) {
-  //   setShoppingItems([
-
-  //     shoppingItems.map((shoppingItem) => {
-  //       if (shoppingItem.id === id) return {newItem, shoppingItems};
-  //       return shoppingItem;
-  //     })
-  //   ]);
-  // }
+  // for editing:
+  const [showForm, setShowForm] = useState(false);
 
   function handleAddItem(newItem) {
     setShoppingItems([
@@ -25,6 +17,16 @@ export default function App({ Component, pageProps }) {
       },
       ...shoppingItems,
     ]);
+  }
+
+  // edit-function:
+  function handleEditItem(id, newItem) {
+    setShoppingItems(
+      shoppingItems.map((shoppingItem) => {
+        if (shoppingItem.id === id) return { ...shoppingItem, ...newItem };
+        return shoppingItem;
+      })
+    );
   }
 
   function handleDeleteItem(id) {
@@ -51,8 +53,12 @@ export default function App({ Component, pageProps }) {
         {...pageProps}
         shoppingItemsWithCategoryColor={shoppingItemsWithCategoryColor}
         onAddItem={handleAddItem}
+        onEditItem={handleEditItem}
         onDeleteItem={handleDeleteItem}
         categories={categories}
+        // for editing:
+        showForm={showForm}
+        setShowForm={setShowForm}
       />
     </>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,12 +7,15 @@ import { categories } from "@/lib/categoriesData";
 export default function ShoppingItemsList({
   shoppingItemsWithCategoryColor,
   onAddItem,
-  onEditItem,
+  onEditItem, // Function to handle editing an existing item.
   onDeleteItem,
 }) {
+  // State for determining the current mode ("add" or "edit").
   const [mode, setMode] = useState("");
+  // State to hold the item being edited.
   const [editingItem, setEditingItem] = useState({});
 
+  // Function to change the mode (e.g., 'edit' or 'add' or reset).
   function handleChangeMode(mode) {
     setMode(mode);
   }
@@ -28,6 +31,7 @@ export default function ShoppingItemsList({
           below.
         </StyledNoItemsMessage>
       )}
+      {/* If the mode is 'edit', show the Form component for editing the item */}
       {mode == "edit" && (
         <Form
           onSubmitItem={onEditItem}
@@ -38,7 +42,7 @@ export default function ShoppingItemsList({
           mode={mode}
         />
       )}
-
+      {/* If the mode is 'add', show the Form component for adding a new item */}
       {mode === "add" && (
         <Form
           onSubmitItem={onAddItem}
@@ -48,6 +52,7 @@ export default function ShoppingItemsList({
           mode={mode}
         />
       )}
+      {/* Button to toggle between 'add' mode and cancelling the form */}
       {mode !== "edit" && (
         <button onClick={() => handleChangeMode(mode === "add" ? "" : "add")}>
           {mode === "add" ? "cancel" : "+"}

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,10 +4,16 @@ import ShoppingItem from "@/components/ShoppingItem/ShoppingItem.js";
 
 import { categories } from "@/lib/categoriesData";
 
+// for editing, in index.js the onEditForm is only passed on to the ShoppingItem component
+
+// pass down onEditItem
 export default function ShoppingItemsList({
   shoppingItemsWithCategoryColor,
   onAddItem,
   onDeleteItem,
+  onEditItem,
+  showForm,
+  setShowForm,
 }) {
   return (
     <main>
@@ -21,7 +27,13 @@ export default function ShoppingItemsList({
         </StyledNoItemsMessage>
       )}
 
-      <FormToCreateShoppingItem onAddItem={onAddItem} categories={categories} />
+      <FormToCreateShoppingItem
+        // add an id in order to be able to jump to the form
+        // - apparently not to be added here but somewhere else
+        // id={createShoppingItemForm}
+        onAddItem={onAddItem}
+        categories={categories}
+      />
       <StyledList>
         {shoppingItemsWithCategoryColor.map((shoppingItem) => {
           return (
@@ -29,6 +41,8 @@ export default function ShoppingItemsList({
               key={shoppingItem.id}
               shoppingItem={shoppingItem}
               onDeleteItem={onDeleteItem}
+              // pass onEditItem to ShoppingItem component
+              onEditItem={onEditItem}
             />
           );
         })}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,20 +1,22 @@
 import styled from "styled-components";
-import FormToCreateShoppingItem from "@/components/FormToCreateShoppingItem/FormToCreateShoppingItem.js";
+import Form from "@/components/Form/Form.js";
 import ShoppingItem from "@/components/ShoppingItem/ShoppingItem.js";
-
+import { useState } from "react";
 import { categories } from "@/lib/categoriesData";
 
-// for editing, in index.js the onEditForm is only passed on to the ShoppingItem component
-
-// pass down onEditItem
 export default function ShoppingItemsList({
   shoppingItemsWithCategoryColor,
   onAddItem,
-  onDeleteItem,
   onEditItem,
-  showForm,
-  setShowForm,
+  onDeleteItem,
 }) {
+  const [mode, setMode] = useState("");
+  const [editingItem, setEditingItem] = useState({});
+
+  function handleChangeMode(mode) {
+    setMode(mode);
+  }
+
   return (
     <main>
       <StyledH1>
@@ -26,14 +28,31 @@ export default function ShoppingItemsList({
           below.
         </StyledNoItemsMessage>
       )}
+      {mode == "edit" && (
+        <Form
+          onSubmitItem={onEditItem}
+          categories={categories}
+          item={editingItem}
+          submitLabel={"UPDATE"}
+          onChangeMode={handleChangeMode}
+          mode={mode}
+        />
+      )}
 
-      <FormToCreateShoppingItem
-        // add an id in order to be able to jump to the form
-        // - apparently not to be added here but somewhere else
-        // id={createShoppingItemForm}
-        onAddItem={onAddItem}
-        categories={categories}
-      />
+      {mode === "add" && (
+        <Form
+          onSubmitItem={onAddItem}
+          categories={categories}
+          submitLabel={"ADD"}
+          onChangeMode={handleChangeMode}
+          mode={mode}
+        />
+      )}
+      {mode !== "edit" && (
+        <button onClick={() => handleChangeMode(mode === "add" ? "" : "add")}>
+          {mode === "add" ? "cancel" : "+"}
+        </button>
+      )}
       <StyledList>
         {shoppingItemsWithCategoryColor.map((shoppingItem) => {
           return (
@@ -41,8 +60,8 @@ export default function ShoppingItemsList({
               key={shoppingItem.id}
               shoppingItem={shoppingItem}
               onDeleteItem={onDeleteItem}
-              // pass onEditItem to ShoppingItem component
-              onEditItem={onEditItem}
+              onEditItem={() => setEditingItem(shoppingItem)}
+              onChangeMode={() => handleChangeMode("edit")}
             />
           );
         })}


### PR DESCRIPTION
### Concept of editing an item and reusing the form.
The key idea is to use a single form for both "adding" and "editing" shopping items, controlled by the mode state. 

- Mode Control: The mode state toggles between "add" and "edit". When in "edit" mode, the form is pre-filled with the item's data, and in "add" mode, it's blank for new entries.

- Reusable Form: The same Form component is used for both actions. Depending on the mode, it either triggers `onAddItem` or `onEditItem`, and the submit button label dynamically changes between "ADD" and "UPDATE".